### PR TITLE
docs: fix the dead benchmark link that blocked every docs deploy

### DIFF
--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -10,7 +10,7 @@ SYNAPSEED helps AI assistants understand your code better. Instead of just readi
 - 📊 **Code history** showing who changed what and why
 - 🏗️ **Quality metrics** with letter grades (A-F) for code health
 
-**Real-world impact:** With SYNAPSEED, AI assistants make ~50% fewer mistakes when understanding code (measured in [our benchmark suite](../../benchmark/)).
+**Real-world impact:** With SYNAPSEED, AI assistants make ~50% fewer mistakes when understanding code (measured in [our benchmark suite](https://github.com/fabriziosalmi/synapseed/tree/main/benchmark)).
 
 ## For Technical Users
 


### PR DESCRIPTION
`docs/guide/introduction.md` links the benchmark suite as `../../benchmark/`. That directory is real, but it sits at the **repository root, not inside `docs/`** — and VitePress only builds `docs/`, so the path resolves outside the site and is a dead link. VitePress fails the entire build on a dead link, so:

- **`Deploy Docs` has failed on every push since 2026-02-18** (~5 months). The published site is frozen at the Feb-17 build.
- The privacy-notice link + CSP merged in #101 are in `main` but **could never publish** — the site build itself was broken.

## The fix

`[our benchmark suite](../../benchmark/)` → `[our benchmark suite](https://github.com/fabriziosalmi/synapseed/tree/main/benchmark)` — pointing at where that content actually is. Intent preserved, target real, and as an absolute URL it isn't subject to the internal dead-link check.

**Not** masked with `ignoreDeadLinks`: that would suppress this and every future dead link.

## Verification

Local `vitepress build`: build now completes (was `1 dead link(s) found`), the benchmark link resolves to the GitHub URL, no residual `../../benchmark` reference, and the **39 built pages carry the privacy link and CSP** from #101. Once this deploys, synapseed's privacy page finally goes live.