### PR TITLE
Guard against missing exit code in ExecutionResult::from_output

### DIFF
--- a/crates/root/src/executor.rs
+++ b/crates/root/src/executor.rs
@@ -103,10 +103,24 @@ pub struct ExecutionResult {
 
 impl ExecutionResult {
     fn from_output(output: Output) -> Self {
+        let exit_code = output.status.code().unwrap_or_else(|| {
+            // On Unix, process terminated by signal; capture signal number if available
+            #[cfg(unix)]
+            {
+                use std::os::unix::process::ExitStatusExt;
+                output.status.signal().unwrap_or(-1)
+            }
+            // On non-Unix platforms, fall back to -1
+            #[cfg(not(unix))]
+            {
+                -1
+            }
+        });
+
         Self {
             stdout: String::from_utf8_lossy(&output.stdout).to_string(),
             stderr: String::from_utf8_lossy(&output.stderr).to_string(),
-            exit_code: output.status.code().unwrap_or(-1),
+            exit_code,
         }
     }
 }


### PR DESCRIPTION
### FabGPT — code quality

**File:** `crates/root/src/executor.rs`

**Rationale:** In `ExecutionResult::from_output`, the line `output.status.code().unwrap_or(-1)` assumes `output.status.code()` always returns `Some(i32)` or `None`, but on Unix systems, `ExitStatus::code()` returns `Option<i32>`, and `None` occurs only when the process was terminated by a signal (e.g., SIGKILL). In that case, `unwrap_or(-1)` silently replaces the signal info with `-1`, losing critical diagnostic data. This is a real defect because `tokio::process::Command::output()` can produce such statuses, and the current behavior hides why a command failed.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `qwen3-coder-next` · task `809a0c912f6931c6` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"809a0c912f6931c6","source":"quality","model":"qwen3-coder-next","severity":"WARN","iterations":2,"inference_s":75.98,"prompt_sha":"e71ee3fd4f441209","triage":"WARN"} -->